### PR TITLE
Improved error handling.

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,9 +47,16 @@ configuration
 
 ```ruby
 # Whether or not compilation should take place
-GulpRails.options[:enabled]   = true
+GulpRails.options[:enabled]         = true
 # The command to run
-GulpRails.options[:command]   = 'gulp'
+GulpRails.options[:command]         = 'gulp'
+# The arguments to pass to the command
+GulpRails.options[:args]            = ''
 # The directory in which your command should be executed
-GulpRails.options[:directory] = Rails.root.join('frontend')
+GulpRails.options[:directory]       = Rails.root.join('frontend')
+# Whether or not run the compilation in development only
+GulpRails.options[:development_only = true
+# Whether or not not raise exceptions when the compilation fails 
+# (this happens when execute returns a exit status different than zero)
+GulpRails.options[:hide_errors]     = false
 ```

--- a/lib/gulp_rails.rb
+++ b/lib/gulp_rails.rb
@@ -1,13 +1,18 @@
+require 'open3'
 require 'gulp_rails/railtie'
 
 module GulpRails
-  
+  class CompilationFailed < RuntimeError
+  end
+
   def self.options
     @options ||= {
       :enabled          => true,
       :command          => 'gulp',
+      :args             => '',
       :directory        => Rails.root.join('frontend'),
-      :development_only => true
+      :development_only => true,
+      :hide_errors      => false
     }
   end
   

--- a/lib/gulp_rails/middleware.rb
+++ b/lib/gulp_rails/middleware.rb
@@ -7,22 +7,47 @@ module GulpRails
   
     def call(env)
       result = @app.call(env)
+
       if GulpRails.options[:enabled] && (GulpRails.options[:development_only] && Rails.env.development?)
         if result[1]['Content-Type'] =~ /\Atext\/html/
-          log "-----> Compiling assets with gulp"
-          gulp_output = `cd #{GulpRails.options[:directory]} && #{GulpRails.options[:command]}`
-          log gulp_output.strip.split("\n").map { |l| "       #{l}"}.join("\n")
-          log "-----> Finished compiling with gulp"
+          log("[GULP:DEBUG ] Starting the compilation in the folder #{GulpRails.options[:directory]}")
+          log("[GULP:DEBUG ]   Running command: #{GulpRails.options[:command]}")
+          perform_execution
         end
       end
+
       result
     end
     
     private
     
     def log(line)
-      Rails.logger.debug line
+      Rails.logger.debug(line)
     end
-  
+
+    def perform_execution
+      command = GulpRails.options[:command]
+      args = GulpRails.options[:args]
+      directory = GulpRails.options[:directory]
+      hide_errors = GulpRails.options[:hide_errors]
+
+      begin
+        pid = value = output = nil
+
+        Open3.popen2e("#{command} #{args}", chdir: directory) do |stdin, stdout_err, thread|
+          pid = thread.pid
+          value = thread.value
+          output = stdout_err.read
+        end
+
+        log("[GULP:DEBUG ]   Process #{pid} exited with status #{value} and output:")
+        log(output.strip.split("\n").map { |l| "[GULP:OUTPUT]     #{l}"}.join("\n"))
+        raise(GulpRails::CompilationFailed, output) unless value.success? || hide_errors
+      rescue Errno::ENOENT
+        log("[GULP:ERROR ]   The Gulp executable #{command} was not found within directory #{directory}.")
+        raise(GulpRails::CompilationFailed, "Gulp executable #{command} not found within #{directory}.") unless hide_errors
+      end
+    end
+
   end
 end

--- a/lib/gulp_rails/middleware.rb
+++ b/lib/gulp_rails/middleware.rb
@@ -1,15 +1,15 @@
 module GulpRails
   class Middleware
-  
+
     def initialize(app)
       @app = app
     end
-  
+
     def call(env)
       result = @app.call(env)
 
       if GulpRails.options[:enabled] && (GulpRails.options[:development_only] && Rails.env.development?)
-        if result[1]['Content-Type'] =~ /\Atext\/html/
+        if env["HTTP_X_REQUESTED_WITH"] != "XMLHttpRequest" && result[1]['Content-Type'] =~ /\Atext\/html/
           log("[GULP:DEBUG ] Starting the compilation in the folder #{GulpRails.options[:directory]}")
           log("[GULP:DEBUG ]   Running command: #{GulpRails.options[:command]}")
           perform_execution
@@ -18,9 +18,9 @@ module GulpRails
 
       result
     end
-    
+
     private
-    
+
     def log(line)
       Rails.logger.debug(line)
     end


### PR DESCRIPTION
Hi!

I've added error handling to the middleware. When the compilation fails (error status different than zero) the middleware will raise the exception and this will be propagated to the browser.
This way we behave more like Sprockets and the user doesn't have to check the terminal to see if compilation succeeded.

This settings can be disabled using:

```ruby
GulpRails.options[:hide_errors] = true
```

Also, I've added `GulpRails.options[:args]` to pass argument (like the task to run) to the executable.

Hope this helps!
  Paolo 